### PR TITLE
Task-hashmap-a

### DIFF
--- a/src/pmse_list_int_ptr.cpp
+++ b/src/pmse_list_int_ptr.cpp
@@ -205,6 +205,17 @@ bool PmseListIntPtr::find(uint64_t key, persistent_ptr<InitData> &item_ptr) {
     return 0;
 }
 
+bool PmseListIntPtr::getPair(uint64_t key, persistent_ptr<KVPair> &item_ptr) {
+    for (auto rec = head; rec != nullptr; rec = rec->next) {
+        if (rec->idValue == key) {
+            item_ptr = rec;
+            return true;
+        }
+    }
+    item_ptr = nullptr;
+    return 0;
+}
+
 void PmseListIntPtr::update(uint64_t key, persistent_ptr<InitData> &value) {
     for (auto rec = head; rec != nullptr; rec = rec->next) {
         if (rec->idValue == key) {

--- a/src/pmse_list_int_ptr.cpp
+++ b/src/pmse_list_int_ptr.cpp
@@ -202,7 +202,7 @@ bool PmseListIntPtr::find(uint64_t key, persistent_ptr<InitData> &item_ptr) {
         }
     }
     item_ptr = nullptr;
-    return 0;
+    return false;
 }
 
 bool PmseListIntPtr::getPair(uint64_t key, persistent_ptr<KVPair> &item_ptr) {
@@ -213,7 +213,7 @@ bool PmseListIntPtr::getPair(uint64_t key, persistent_ptr<KVPair> &item_ptr) {
         }
     }
     item_ptr = nullptr;
-    return 0;
+    return false;
 }
 
 void PmseListIntPtr::update(uint64_t key, persistent_ptr<InitData> &value) {

--- a/src/pmse_list_int_ptr.h
+++ b/src/pmse_list_int_ptr.h
@@ -77,6 +77,7 @@ public:
     void insertKV_capped(persistent_ptr<KVPair> &key, persistent_ptr<InitData> &value,
                          bool isCapped, uint64_t maxDoc, uint64_t sizeOfColl);
     bool find(uint64_t key, persistent_ptr<InitData> &item_ptr);
+    bool getPair(uint64_t key, persistent_ptr<KVPair> &item_ptr);
     void update(uint64_t key, persistent_ptr<InitData> &value);
     void deleteKV(uint64_t key, persistent_ptr<KVPair> &deleted);
     bool hasKey(uint64_t key);

--- a/src/pmse_list_int_ptr.h
+++ b/src/pmse_list_int_ptr.h
@@ -78,7 +78,7 @@ public:
 			bool isCapped, uint64_t maxDoc, uint64_t sizeOfColl);
 	bool find(uint64_t key, persistent_ptr<InitData> &item_ptr);
 	void update(uint64_t key, persistent_ptr<InitData> value);
-	void deleteKV(uint64_t key);
+	void deleteKV(uint64_t key, persistent_ptr<KVPair> &deleted);
 	bool hasKey(uint64_t key);
 	void clear();
 	void setPool();

--- a/src/pmse_list_int_ptr.h
+++ b/src/pmse_list_int_ptr.h
@@ -55,57 +55,57 @@ using namespace nvml::obj;
 namespace mongo {
 
 struct InitData {
-	uint64_t size;
-	char data[];
+    uint64_t size;
+    char data[];
 };
 
 struct _pair {
-	p<uint64_t> idValue;
-	persistent_ptr<InitData> ptr;
-	persistent_ptr<_pair> next;
+    p<uint64_t> idValue;
+    persistent_ptr<InitData> ptr;
+    persistent_ptr<_pair> next;
 };
 
 typedef struct _pair KVPair;
 
 class PmseListIntPtr {
-	template<typename T>
-	friend class PmseMap;
+    template<typename T>
+    friend class PmseMap;
 public:
-	PmseListIntPtr();
-	~PmseListIntPtr();
-	void insertKV(uint64_t key, persistent_ptr<InitData> value);
-	void insertKV_capped(uint64_t key, persistent_ptr<InitData> value,
-			bool isCapped, uint64_t maxDoc, uint64_t sizeOfColl);
-	bool find(uint64_t key, persistent_ptr<InitData> &item_ptr);
-	void update(uint64_t key, persistent_ptr<InitData> value);
-	void deleteKV(uint64_t key, persistent_ptr<KVPair> &deleted);
-	bool hasKey(uint64_t key);
-	void clear();
-	void setPool();
-	uint64_t size();
-	uint64_t getNextId();
+    PmseListIntPtr();
+    ~PmseListIntPtr();
+    void insertKV(uint64_t key, persistent_ptr<InitData> value);
+    void insertKV_capped(uint64_t key, persistent_ptr<InitData> value,
+                         bool isCapped, uint64_t maxDoc, uint64_t sizeOfColl);
+    bool find(uint64_t key, persistent_ptr<InitData> &item_ptr);
+    void update(uint64_t key, persistent_ptr<InitData> value);
+    void deleteKV(uint64_t key, persistent_ptr<KVPair> &deleted);
+    bool hasKey(uint64_t key);
+    void clear();
+    void setPool();
+    uint64_t size();
+    uint64_t getNextId();
 
 private:
-	persistent_ptr<KVPair> getHead() {
-		return head;
-	}
-	persistent_ptr<KVPair> head;
-	persistent_ptr<KVPair> tail;
-	persistent_ptr<KVPair> deleted;
-	persistent_ptr<KVPair> deletedTail;
-	p<uint64_t> counterDeleted;
-	p<uint64_t> counter;
-	p<uint64_t> _size;
-	pool_base pop;
+    persistent_ptr<KVPair> getHead() {
+        return head;
+    }
+    persistent_ptr<KVPair> head;
+    persistent_ptr<KVPair> tail;
+    persistent_ptr<KVPair> deleted;
+    persistent_ptr<KVPair> deletedTail;
+    p<uint64_t> counterDeleted;
+    p<uint64_t> counter;
+    p<uint64_t> _size;
+    pool_base pop;
 
-	p<uint64_t> sizeOfFirstData;
-	enum FreeSpace {
-		NO = 0, YES = 1, BLOCKED = 2
-	};
-	FreeSpace isSpace = YES;
-	bool isFullCapped;
-	persistent_ptr<KVPair> first;
-	p<uint64_t> actualSizeOfCollecion = 0;
+    p<uint64_t> sizeOfFirstData;
+    enum FreeSpace {
+        NO = 0, YES = 1, BLOCKED = 2
+    };
+    FreeSpace isSpace = YES;
+    bool isFullCapped;
+    persistent_ptr<KVPair> first;
+    p<uint64_t> actualSizeOfCollecion = 0;
 };
 }
 #endif /* SRC_MONGO_DB_MODULES_PMSTORE_SRC_PMSE_LIST_INT_PTR_H_ */

--- a/src/pmse_list_int_ptr.h
+++ b/src/pmse_list_int_ptr.h
@@ -73,11 +73,11 @@ class PmseListIntPtr {
 public:
     PmseListIntPtr();
     ~PmseListIntPtr();
-    void insertKV(uint64_t key, persistent_ptr<InitData> value);
-    void insertKV_capped(uint64_t key, persistent_ptr<InitData> value,
+    void insertKV(persistent_ptr<KVPair> &key, persistent_ptr<InitData> &value);
+    void insertKV_capped(persistent_ptr<KVPair> &key, persistent_ptr<InitData> &value,
                          bool isCapped, uint64_t maxDoc, uint64_t sizeOfColl);
     bool find(uint64_t key, persistent_ptr<InitData> &item_ptr);
-    void update(uint64_t key, persistent_ptr<InitData> value);
+    void update(uint64_t key, persistent_ptr<InitData> &value);
     void deleteKV(uint64_t key, persistent_ptr<KVPair> &deleted);
     bool hasKey(uint64_t key);
     void clear();

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -114,22 +114,11 @@ public:
     }
 
     bool find(uint64_t id, persistent_ptr<T> &value) {
-        persistent_ptr<InitData> obj;
-        if (_list[id % _size]->find(id, obj)) {
-            value = obj;
-            return true;
-        }
-        value = nullptr;
-        return false;
+        return _list[id % _size]->find(id, value);
     }
 
     bool getPair(uint64_t id, persistent_ptr<KVPair> &value) {
-        persistent_ptr<KVPair> obj;
-        if (_list[id % _size]->getPair(id, obj)) {
-            value = obj;
-            return true;
-        }
-        return false;
+        return _list[id % _size]->getPair(id, value);
     }
 
     bool remove(uint64_t id) {

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -140,6 +140,7 @@ public:
     }
 
     void initialize(bool firstRun) {
+        pop = pool_by_vptr(this);
         for(int i = 0; i < _size; i++) {
             if (firstRun) {
                 try {
@@ -163,6 +164,7 @@ public:
 private:
     const int _size;
     const bool _isCapped;
+    pool_base pop;
     p<uint64_t> _counter = 0;
     p<uint64_t> _hashmapSize = 0;
     p<uint64_t> _maxDocuments;
@@ -176,13 +178,12 @@ private:
             return _list[listNumber]->head;
         return {};
     }
+
     persistent_ptr<KVPair> getNextId() {
         persistent_ptr<KVPair> temp = nullptr;
         if(_deleted == nullptr) {
             if(_counter != std::numeric_limits<uint64_t>::max()-1) {
                 this->_counter++;
-                pool_base pop;
-                pop = pool_by_vptr(this);
                 try {
                     transaction::exec_tx(pop, [&] {
                         temp = make_persistent<KVPair>();

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -51,26 +51,24 @@ using namespace nvml::obj;
 
 namespace mongo {
 
-const uint64_t HASHTABLE_SIZE = 1000;
 const uint64_t CAPPED_SIZE = 1;
-
 
 class PmseRecordCursor;
 
 template<typename T>
 class PmseMap {
-	friend PmseRecordCursor;
+    friend PmseRecordCursor;
 public:
-	PmseMap() = default;
-	PmseMap(bool isCapped, p<uint64_t> maxDoc, p<uint64_t> sizeOfColl) :
-				_size(isCapped ? CAPPED_SIZE : HASHTABLE_SIZE) {
-		this->isCapped = isCapped;
-		maxDocuments = maxDoc;
-		sizeOfCollection = sizeOfColl;
-		list = make_persistent<persistent_ptr<PmseListIntPtr>[]>(_size);
-	}
+    PmseMap() = default;
 
-	~PmseMap() = default;
+    PmseMap(bool isCapped, uint64_t maxDoc, uint64_t sizeOfColl, uint64_t size = 1000)
+            : _size(isCapped ? CAPPED_SIZE : size), isCapped(isCapped) {
+        maxDocuments = maxDoc;
+        sizeOfCollection = sizeOfColl;
+        list = make_persistent<persistent_ptr<PmseListIntPtr>[]>(_size);
+    }
+
+    ~PmseMap() = default;
 
 	uint64_t insert(persistent_ptr<T> value) {
 		uint64_t id = getNextId();
@@ -158,7 +156,7 @@ private:
 		this->counter++;
 		return counter;
 	}
-	bool isCapped;
+	const bool isCapped;
 	p<uint64_t> maxDocuments;
 	p<uint64_t> sizeOfCollection;
 	p<uint64_t> counterCapped = 0;

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -129,7 +129,6 @@ public:
             value = obj;
             return true;
         }
-        value = nullptr;
         return false;
     }
 
@@ -198,8 +197,6 @@ private:
         } else {
             temp = _deleted;
             uint64_t id = 0;
-            pool_base pop;
-            pop = pool_by_vptr(this);
             id = _deleted->idValue;
             _deleted = _deleted->next;
             return temp;

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -123,6 +123,16 @@ public:
         return false;
     }
 
+    bool getPair(uint64_t id, persistent_ptr<KVPair> &value) {
+        persistent_ptr<KVPair> obj;
+        if (_list[id % _size]->getPair(id, obj)) {
+            value = obj;
+            return true;
+        }
+        value = nullptr;
+        return false;
+    }
+
     bool remove(uint64_t id) {
         _list[id % _size]->deleteKV(id, _deleted);
         _hashmapSize--;

--- a/src/pmse_record_store.cpp
+++ b/src/pmse_record_store.cpp
@@ -209,6 +209,9 @@ boost::optional<Record> PmseRecordCursor::next() {
 boost::optional<Record> PmseRecordCursor::seekExact(const RecordId& id) {
     persistent_ptr<InitData> obj = nullptr;
     bool status = _mapper->getPair(id.repr(), _cur);
+    if(_cur == nullptr || _cur->ptr == nullptr) {
+        return boost::none;
+    }
     obj = _cur->ptr;
     if (!status || !obj) {
         return boost::none;

--- a/src/pmse_record_store.h
+++ b/src/pmse_record_store.h
@@ -64,20 +64,63 @@ public:
     boost::optional<Record> seekExact(const RecordId& id) final;
 
     void save() final {
+        auto temp = _cur;
+        auto row = actual;
+        if(temp != nullptr) {
+            if(temp->next != nullptr) {
+                temp = temp->next;
+            } else {
+                temp = nullptr;
+                while(temp == nullptr && ++row < _mapper->_size) {
+                    persistent_ptr<KVPair> head = _mapper->getFirstPtr(row);
+                    if(head != nullptr) {
+                        temp = head;
+                        break;
+                    }
+                }
+            }
+        } else {
+            while(temp == nullptr && row < _mapper->_size) {
+                persistent_ptr<KVPair> head = _mapper->getFirstPtr(row);
+                if(head != nullptr) {
+                    temp = head;
+                    break;
+                }
+                row++;
+            }
+        }
+        _restorePoint = temp;
     }
 
     bool restore() final {
-        // TODO: Implement or delete
+        if(_eof)
+            return true;
+        if(_restorePoint == nullptr) {
+            _eof = true;
+            return true;
+        }
+        if(_cur == nullptr) {
+            _cur = _restorePoint;
+            return true;
+        }
+        if(!_mapper->hasId(_cur->idValue)) {
+            _cur = _restorePoint;
+        }
         return true;
     }
 
-    void detachFromOperationContext() final {
-    }
-    void reattachToOperationContext(OperationContext* txn) final {
+    void detachFromOperationContext() final {}
+
+    void reattachToOperationContext(OperationContext* txn) final {}
+
+    void saveUnpositioned() {
+        _eof = true;
     }
 private:
     persistent_ptr<PmseMap<InitData>> _mapper;
     persistent_ptr<KVPair> _cur;
+    persistent_ptr<KVPair> _restorePoint;
+    p<bool> _eof = false;
     p<int> actual = 0;
     PMEMoid _currentOid = OID_NULL;
 };

--- a/src/pmse_record_store.h
+++ b/src/pmse_record_store.h
@@ -63,59 +63,15 @@ public:
 
     boost::optional<Record> seekExact(const RecordId& id) final;
 
-    void save() final {
-        auto temp = _cur;
-        auto row = actual;
-        if(temp != nullptr) {
-            if(temp->next != nullptr) {
-                temp = temp->next;
-            } else {
-                temp = nullptr;
-                while(temp == nullptr && ++row < _mapper->_size) {
-                    persistent_ptr<KVPair> head = _mapper->getFirstPtr(row);
-                    if(head != nullptr) {
-                        temp = head;
-                        break;
-                    }
-                }
-            }
-        } else {
-            while(temp == nullptr && row < _mapper->_size) {
-                persistent_ptr<KVPair> head = _mapper->getFirstPtr(row);
-                if(head != nullptr) {
-                    temp = head;
-                    break;
-                }
-                row++;
-            }
-        }
-        _restorePoint = temp;
-    }
+    void save() final;
 
-    bool restore() final {
-        if(_eof)
-            return true;
-        if(_restorePoint == nullptr) {
-            _eof = true;
-            return true;
-        }
-        if(_cur == nullptr) {
-            _cur = _restorePoint;
-            return true;
-        }
-        if(!_mapper->hasId(_cur->idValue)) {
-            _cur = _restorePoint;
-        }
-        return true;
-    }
+    bool restore() final;
 
     void detachFromOperationContext() final {}
 
     void reattachToOperationContext(OperationContext* txn) final {}
 
-    void saveUnpositioned() {
-        _eof = true;
-    }
+    void saveUnpositioned();
 private:
     persistent_ptr<PmseMap<InitData>> _mapper;
     persistent_ptr<KVPair> _cur;


### PR DESCRIPTION
- Cursor save/saveUnpositioned/restore implementation
- Cursor bugfix (iterator continued execution on deleted items)
- PmseMap: Pool deduction moved to initialize function
- boose::none instead of {}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/5)
<!-- Reviewable:end -->
