### PR TITLE
cappedCollection: fix size of object

### DIFF
--- a/src/pmse_list_int_ptr.cpp
+++ b/src/pmse_list_int_ptr.cpp
@@ -88,9 +88,8 @@ void PmseListIntPtr::insertKV_capped(persistent_ptr<KVPair> &key,
             key->next = nullptr;
 
             isFullCapped = false;
-            size_t pair_size = pmemobj_alloc_usable_size(key.raw());
             size_t value_size = pmemobj_alloc_usable_size(value.raw());
-            uint64_t tempSize = actualSizeOfCollecion + pair_size + value_size;
+            uint64_t tempSize = actualSizeOfCollecion + value_size;
 
             if(tempSize >= sizeOfColl) {
                 if((tempSize - (pmemobj_alloc_usable_size(head.raw()) + sizeOfFirstData)) > sizeOfColl)
@@ -114,7 +113,7 @@ void PmseListIntPtr::insertKV_capped(persistent_ptr<KVPair> &key,
                     }
 
                     actualSizeOfCollecion -= (sizeOfFirstData + pmemobj_alloc_usable_size(head.raw()))
-                                    + pair_size + value_size;
+                                     + value_size;
 
                     if(!isFullCapped)
                         isFullCapped = true;

--- a/src/pmse_list_int_ptr.cpp
+++ b/src/pmse_list_int_ptr.cpp
@@ -96,9 +96,9 @@ void PmseListIntPtr::insertKV_capped(persistent_ptr<KVPair> &key,
                     isSpace = BLOCKED;
                 else
                     isSpace = NO;
-            }
-            else
+            } else {
                 isSpace = YES;
+            }
 
             if(head != nullptr) {
                 if(_size == maxDoc || isSpace == NO) {

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -167,8 +167,6 @@ public:
             });
             _counter = 0;
             _hashmapSize = 0;
-            _maxDocuments = 0;
-            _sizeOfCollection = 0;
             _counterCapped = 0;
             _dataSize = 0;
         } catch (nvml::transaction_alloc_error &e) {


### PR DESCRIPTION
Fix size of object, actual tests which results is correct: 
capped9.js
cappeda.js
capped_update.js
capped_empty.js
capped_convertToCapped1.js
clone_as_capped_nonexistant.js
convert_to_capped_nonexistant.js

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/15)
<!-- Reviewable:end -->
