### PR TITLE
Seek (IndexSeekPoint) implemented

### DIFF
--- a/src/pmse_index_cursor.cpp
+++ b/src/pmse_index_cursor.cpp
@@ -672,7 +672,7 @@ boost::optional<IndexKeyEntry> PmseCursor::seek(
                 RequestedInfo parts = kKeyAndLoc) {
     BSONObj key = IndexEntryComparison::makeQueryObject(seekPoint, _forward);
     const auto discriminator = _forward ? true : false;
-    return seek(key,discriminator,parts);
+    return seek(key, discriminator, parts);
 }
 
 boost::optional<IndexKeyEntry> PmseCursor::seekExact(

--- a/src/pmse_index_cursor.cpp
+++ b/src/pmse_index_cursor.cpp
@@ -670,8 +670,9 @@ boost::optional<IndexKeyEntry> PmseCursor::seek(
 boost::optional<IndexKeyEntry> PmseCursor::seek(
                 const IndexSeekPoint& seekPoint,
                 RequestedInfo parts = kKeyAndLoc) {
-    log() << "seek not implemented";
-    return boost::none;
+    BSONObj key = IndexEntryComparison::makeQueryObject(seekPoint, _forward);
+    const auto discriminator = _forward ? true : false;
+    return seek(key,discriminator,parts);
 }
 
 boost::optional<IndexKeyEntry> PmseCursor::seekExact(


### PR DESCRIPTION
Corrects ~90 tests, but causes these to enter into infinite loop:
-collation.js
-countc.js
-cursor4.js
-distinct1.js
-distinct_array1.js
-distinct_compound_index.js
-distinct_index1.js
-distinct_index2.js
-distinct_speed1.js
-exists4.js
-exists.js
-explain_distinct.js
-explain_multikey.js
-explain_multiplan.js
-geo_s2descindex.js
-geo_s2index.js
-geo_s2nongeoarray.js
-geo_s2nonstring.js
-geo_s2twofields.js
-in2.js
-in3.js
-index_check6.js
-index_stats.js
-ne1.js
-ne2.js
-nin.js
-not1.js
-null.js
-or3.
-regex5.js
 Fixes  #10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/28)
<!-- Reviewable:end -->
