### PR TITLE
Null Object type supported in cursor

### DIFF
--- a/src/pmse_index_cursor.cpp
+++ b/src/pmse_index_cursor.cpp
@@ -375,14 +375,11 @@ bool PmseCursor::correctType(BSONObj record) {
 
     BSONType typeRecord = record.firstElementType();
 
-    if(cursorType == EOO)
-        return true;
-
     if (cursorType == typeRecord)
         return true;
 
-    if (cursorType == MinKey || cursorType == MaxKey
-                    || cursorType == Undefined) {
+    if (cursorType == MinKey || cursorType == MaxKey || cursorType == Undefined
+                    || cursorType == EOO || cursorType == jstNULL) {
         return true;
     }
     switch (cursorType) {


### PR DESCRIPTION
Correct test:
jstests/core/or_inexact.js

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/47)
<!-- Reviewable:end -->
