### PR TITLE
Correction in cursor seek when finding end position

### DIFF
--- a/src/pmse_index_cursor.cpp
+++ b/src/pmse_index_cursor.cpp
@@ -535,9 +535,17 @@ boost::optional<IndexKeyEntry> PmseCursor::seek(
                 return boost::none;
             }
         }
-        return IndexKeyEntry(
+        if (_endPosition
+                        && SimpleBSONObjComparator::kInstance.evaluate(
+                                        _cursor.node->keys[_cursor.index].getBSON()
+                                                        == _endPosition->getBSON())) {
+            return boost::none;
+        }
+        else{
+            return IndexKeyEntry(
                         _cursor.node->keys[_cursor.index].getBSON(),
                         _cursor.node->values_array[_cursor.index]);
+        }
     }
 
     /*


### PR DESCRIPTION
Corrects:
All.js,
geo_haystack1.js,
geo_haystack2.js.

Looks like breaks:
indexr.js

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/49)
<!-- Reviewable:end -->
