### PR TITLE
Exception for restore method in capped collection

### DIFF
--- a/src/pmse_record_store.cpp
+++ b/src/pmse_record_store.cpp
@@ -313,7 +313,7 @@ void PmseRecordCursor::save() {
 }
 
 bool PmseRecordCursor::restore() {
-    if(_mapper->isCapped()) {
+    if(_mapper->isCapped() && _restorePoint == nullptr) {
         _eof = true;
         return false;
     }
@@ -329,6 +329,7 @@ bool PmseRecordCursor::restore() {
     }
     if(!_mapper->hasId(_cur->idValue)) {
         _cur = _restorePoint;
+        _restorePoint = nullptr;
         _lastMoveWasRestore = true;
         actual = _actualAfterRestore;
     }

--- a/src/pmse_sorted_data_interface.cpp
+++ b/src/pmse_sorted_data_interface.cpp
@@ -82,8 +82,7 @@ Status PmseSortedDataInterface::insert(OperationContext* txn,
     persistent_ptr<char> obj;
 
     try {
-        transaction::exec_tx(pm_pool,
-                             [&] {
+        transaction::exec_tx(pm_pool, [&] {
             obj = pmemobj_tx_alloc(owned.objsize(), 1);
             memcpy( (void*)obj.get(), owned.objdata(), owned.objsize());
         });
@@ -108,9 +107,8 @@ void PmseSortedDataInterface::unindex(OperationContext* txn, const BSONObj& key,
                                       const RecordId& loc, bool dupsAllowed) {
     BSONObj owned = key.getOwned();
     try {
-        transaction::exec_tx(pm_pool,
-        [&] {
-            if(tree->remove(pm_pool, owned, loc, dupsAllowed, _desc->keyPattern(), txn))
+        transaction::exec_tx(pm_pool, [&] {
+            if (tree->remove(pm_pool, owned, loc, dupsAllowed, _desc->keyPattern(), txn))
                 --tree->_records;
         });
 


### PR DESCRIPTION
Save and restore() can be called when big collection scan occurs.

Additionally fixes:
`jstests/core/rename.js`

Fixes #48

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/52)
<!-- Reviewable:end -->
