### PR TITLE
Missing endBackup implementation

### DIFF
--- a/src/pmse_engine.h
+++ b/src/pmse_engine.h
@@ -102,6 +102,10 @@ public:
         return Status::OK();
     }
 
+    virtual void endBackup(OperationContext* txn) {
+        return;
+    }
+
     virtual bool supportsDirectoryPerDB() const {
         return false;
     }


### PR DESCRIPTION
This pull request adds missing function. Default implementation was taken from KVEngine class instead of StorageEngine, so I decided to override.
Fixes #58

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/61)
<!-- Reviewable:end -->
