### PR TITLE
Reimplemented restore functionality

### DIFF
--- a/src/pmse_engine.cpp
+++ b/src/pmse_engine.cpp
@@ -79,7 +79,7 @@ Status PmseEngine::createRecordStore(OperationContext* opCtx, StringData ns, Str
                                      const CollectionOptions& options) {
     auto status = Status::OK();
     try {
-        auto record_store = stdx::make_unique<PmseRecordStore>(ns, ident, options, _DBPATH, _pool_handler);
+        auto record_store = stdx::make_unique<PmseRecordStore>(ns, ident, options, _DBPATH, &_pool_handler);
         identList->insertKV(ident.toString().c_str(), ns.toString().c_str());
 
     } catch(std::exception &e) {
@@ -93,14 +93,14 @@ std::unique_ptr<RecordStore> PmseEngine::getRecordStore(OperationContext* opCtx,
                                                         StringData ident,
                                                         const CollectionOptions& options) {
     identList->update(ident.toString().c_str(), ns.toString().c_str());
-    return stdx::make_unique<PmseRecordStore>(ns, ident, options, _DBPATH, _pool_handler);
+    return stdx::make_unique<PmseRecordStore>(ns, ident, options, _DBPATH, &_pool_handler);
 }
 
 Status PmseEngine::createSortedDataInterface(OperationContext* opCtx,
                                              StringData ident,
                                              const IndexDescriptor* desc) {
     try {
-        auto sorted_data_interface = PmseSortedDataInterface(ident, desc, _DBPATH, _pool_handler);
+        auto sorted_data_interface = PmseSortedDataInterface(ident, desc, _DBPATH, &_pool_handler);
         identList->insertKV(ident.toString().c_str(), "");
     } catch (std::exception &e) {
         return Status(ErrorCodes::OutOfDiskSpace, e.what());
@@ -111,7 +111,7 @@ Status PmseEngine::createSortedDataInterface(OperationContext* opCtx,
 SortedDataInterface* PmseEngine::getSortedDataInterface(OperationContext* opCtx,
                                                         StringData ident,
                                                         const IndexDescriptor* desc) {
-    return new PmseSortedDataInterface(ident, desc, _DBPATH, _pool_handler);
+    return new PmseSortedDataInterface(ident, desc, _DBPATH, &_pool_handler);
 }
 
 Status PmseEngine::dropIdent(OperationContext* opCtx, StringData ident) {

--- a/src/pmse_list_int_ptr.cpp
+++ b/src/pmse_list_int_ptr.cpp
@@ -70,6 +70,7 @@ void PmseListIntPtr::insertKV(const persistent_ptr<KVPair> &key,
         transaction::exec_tx(pop, [this, &key, &value] {
             key->ptr = value;
             key->next = nullptr;
+            key->position = counter++;
             if (head != nullptr) {
                 tail->next = key;
                 tail = key;

--- a/src/pmse_list_int_ptr.h
+++ b/src/pmse_list_int_ptr.h
@@ -64,6 +64,7 @@ struct _pair {
     p<uint64_t> idValue;
     persistent_ptr<InitData> ptr;
     persistent_ptr<_pair> next;
+    p<uint64_t> position;
 };
 
 typedef struct _pair KVPair;

--- a/src/pmse_record_store.h
+++ b/src/pmse_record_store.h
@@ -79,6 +79,7 @@ class PmseRecordCursor final : public SeekableRecordCursor {
     void moveToNext(bool inNext = true);
     void moveToLast();
     void moveBackward();
+    bool checkPosition();
 
     persistent_ptr<PmseMap<InitData>> _mapper;
     persistent_ptr<KVPair> _before;
@@ -88,8 +89,10 @@ class PmseRecordCursor final : public SeekableRecordCursor {
     p<bool> _isCapped;
     p<bool> _forward;
     p<bool> _lastMoveWasRestore;
+    p<bool> _positionCheck;
     p<int64_t> actual = -1;
     p<int64_t> _actualAfterRestore = 0;
+    p<uint64_t> position;
     PMEMoid _currentOid = OID_NULL;
 };
 

--- a/src/pmse_record_store.h
+++ b/src/pmse_record_store.h
@@ -46,6 +46,7 @@
 #include "mongo/platform/basic.h"
 #include "mongo/db/catalog/collection_options.h"
 #include "mongo/db/storage/capped_callback.h"
+#include "mongo/db/storage/record_store.h"
 #include "mongo/stdx/memory.h"
 
 using namespace nvml::obj;
@@ -90,7 +91,7 @@ class PmseRecordCursor final : public SeekableRecordCursor {
     p<bool> _forward;
     p<bool> _lastMoveWasRestore;
     p<bool> _positionCheck;
-    p<int64_t> actual = -1;
+    p<int64_t> actualListNumber = -1;
     p<int64_t> _actualAfterRestore = 0;
     p<uint64_t> position;
     PMEMoid _currentOid = OID_NULL;
@@ -101,7 +102,7 @@ class PmseRecordStore : public RecordStore {
     PmseRecordStore(StringData ns, StringData ident,
                     const CollectionOptions& options,
                     StringData dbpath,
-                    std::map<std::string, pool_base> &pool_handler);
+                    std::map<std::string, pool_base> *pool_handler);
 
     ~PmseRecordStore() = default;
 

--- a/src/pmse_sorted_data_interface.cpp
+++ b/src/pmse_sorted_data_interface.cpp
@@ -47,11 +47,11 @@ const int TempKeyMaxSize = 1024;
 PmseSortedDataInterface::PmseSortedDataInterface(StringData ident,
                                                  const IndexDescriptor* desc,
                                                  StringData dbpath,
-                                                 std::map<std::string, pool_base> &pool_handler) {
+                                                 std::map<std::string, pool_base> *pool_handler) {
     _desc = desc;
     try {
-        if (pool_handler.count(ident.toString()) > 0) {
-            pm_pool = pool<PmseTree>(pool_handler[ident.toString()]);
+        if (pool_handler->count(ident.toString()) > 0) {
+            pm_pool = pool<PmseTree>((*pool_handler)[ident.toString()]);
         } else {
             filepath = dbpath;
             std::string filename = filepath.toString() + ident.toString();
@@ -63,7 +63,7 @@ PmseSortedDataInterface::PmseSortedDataInterface(StringData ident,
             } else {
                 pm_pool = pool<PmseTree>::open(filename.c_str(), "pmse");
             }
-            pool_handler.insert(std::pair<std::string, pool_base>(ident.toString(), pm_pool));
+            pool_handler->insert(std::pair<std::string, pool_base>(ident.toString(), pm_pool));
         }
         tree = pm_pool.get_root();
     } catch (std::exception &e) {

--- a/src/pmse_sorted_data_interface.h
+++ b/src/pmse_sorted_data_interface.h
@@ -52,7 +52,7 @@ class PmseSortedDataInterface : public SortedDataInterface {
 public:
 
     PmseSortedDataInterface(StringData ident, const IndexDescriptor* desc,
-                            StringData dbpath, std::map<std::string, pool_base> &pool_handler);
+                            StringData dbpath, std::map<std::string, pool_base> *pool_handler);
 
     virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
                                                        bool dupsAllowed) override;


### PR DESCRIPTION
Reimplemented cursor methods in Record Store: save(),restore() and next() to provide stability while another thread remove many documents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/69)
<!-- Reviewable:end -->
