### PR TITLE
Modify save() method to support multithreading

### DIFF
--- a/src/pmse_index_cursor.cpp
+++ b/src/pmse_index_cursor.cpp
@@ -309,6 +309,7 @@ void PmseCursor::setEndPosition(const BSONObj& key, bool inclusive) {
 boost::optional<IndexKeyEntry> PmseCursor::next(
                 RequestedInfo parts = kKeyAndLoc) {
     boost::optional<IndexKeyEntry> entry;
+    std::lock_guard<nvml::obj::mutex> lock(_tree->pmutex);
     /**
      * Find next correct value for cursor
      */
@@ -577,6 +578,7 @@ boost::optional<IndexKeyEntry> PmseCursor::seek(
                 const BSONObj& key, bool inclusive, RequestedInfo parts =
                                 kKeyAndLoc) {
     boost::optional<IndexKeyEntry> entry;
+    std::lock_guard<nvml::obj::mutex> lock(_tree->pmutex);
     const auto discriminator = inclusive ? KeyString::kInclusive : KeyString::kExclusiveBefore;
     /**
      * Remember current search result to return it
@@ -831,6 +833,8 @@ boost::optional<IndexKeyEntry> PmseCursor::seek(
                 const IndexSeekPoint& seekPoint,
                 RequestedInfo parts = kKeyAndLoc) {
     boost::optional<IndexKeyEntry> entry;
+    std::lock_guard<nvml::obj::mutex> lock(_tree->pmutex);
+
     BSONObj key = IndexEntryComparison::makeQueryObject(seekPoint, _forward);
     auto discriminator = KeyString::kInclusive;
 

--- a/src/pmse_index_cursor.h
+++ b/src/pmse_index_cursor.h
@@ -63,6 +63,7 @@ public:
     void reattachToOperationContext(OperationContext* opCtx);
 
 private:
+    virtual boost::optional<IndexKeyEntry> iterateToNext(RequestedInfo parts);
     boost::optional<IndexKeyEntry> seekInTree(const BSONObj& key, KeyString::Discriminator discriminator,
                                         RequestedInfo parts);
     persistent_ptr<PmseTreeNode> find_leaf(persistent_ptr<PmseTreeNode> node,

--- a/src/pmse_index_cursor.h
+++ b/src/pmse_index_cursor.h
@@ -101,6 +101,7 @@ private:
 
     bool _wasMoved;
     bool _eofRestore;
+    bool _wasRestore=false;
 
 };
 }

--- a/src/pmse_tree.h
+++ b/src/pmse_tree.h
@@ -44,6 +44,7 @@
 #include <libpmemobj++/pext.hpp>
 #include <libpmemobj++/pool.hpp>
 #include "libpmemobj++/transaction.hpp"
+#include "libpmemobj++/mutex.hpp"
 
 using namespace nvml::obj;
 
@@ -185,6 +186,7 @@ private:
     persistent_ptr<PmseTreeNode> first;
     persistent_ptr<PmseTreeNode> last;
     BSONObj _ordering;
+    nvml::obj::mutex pmutex;
 };
 
 }


### PR DESCRIPTION
Save() method in Index Cursor is modified to be empty. Moving to next
record and remembering its value is done in seek() and next() method.
This simplifies multithreading management by decreasing API methods
which can be called simultaneously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/75)
<!-- Reviewable:end -->
