### PR TITLE
SConscript modification to prevent build failure

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -12,7 +12,6 @@ env.Library(
         'src/pmse_record_store.cpp',
         'src/pmse_list_int_ptr.cpp',
         'src/pmse_list.cpp',
-        'src/pmse_record_store.cpp',
         'src/pmse_sorted_data_interface.cpp',
         'src/pmse_tree.cpp',
         'src/pmse_index_cursor.cpp',


### PR DESCRIPTION
Modification to prevent linker error, that appears when building latest MongoDB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/114)
<!-- Reviewable:end -->
