### PR TITLE
Index thread safe counters

### DIFF
--- a/src/pmse_change.cpp
+++ b/src/pmse_change.cpp
@@ -162,7 +162,7 @@ void InsertIndexChange::rollback() {
         transaction::exec_tx(_pop, [this] {
             IndexKeyEntry entry(_key.getOwned(), _loc);
             _tree->remove(_pop, entry, _dupsAllowed, _desc->keyPattern(), nullptr);
-            --_tree->_records;
+            _tree->_records.fetch_sub(1);
         });
     } catch (std::exception &e) {
         log() << e.what();
@@ -179,7 +179,7 @@ void RemoveIndexChange::rollback() {
     IndexKeyEntry entry(_key.getOwned(), _loc);
     status = _tree->insert(_pop, entry, _ordering, _dupsAllowed);
     if (status == Status::OK()) {
-        ++_tree->_records;
+        _tree->_records.fetch_add(1);
     }
 }
 

--- a/src/pmse_engine.cpp
+++ b/src/pmse_engine.cpp
@@ -126,7 +126,8 @@ Status PmseEngine::createSortedDataInterface(OperationContext* opCtx,
 SortedDataInterface* PmseEngine::getSortedDataInterface(OperationContext* opCtx,
                                                         StringData ident,
                                                         const IndexDescriptor* desc) {
-    return new PmseSortedDataInterface(ident, desc, _dbPath, &_poolHandler);
+    return new PmseSortedDataInterface(ident, desc, _dbPath,
+                                       &_poolHandler, (_needCheck ? true : false));
 }
 
 Status PmseEngine::dropIdent(OperationContext* opCtx, StringData ident) {

--- a/src/pmse_engine.cpp
+++ b/src/pmse_engine.cpp
@@ -53,20 +53,32 @@ namespace mongo {
 PmseEngine::PmseEngine(std::string dbpath) : _dbPath(dbpath) {
     std::string path = _dbPath+_kIdentFilename.toString();
     if (!boost::filesystem::exists(path)) {
-        pop = pool<PmseList>::create(path, "pmse_identlist", 4 * PMEMOBJ_MIN_POOL,
-                                         0664);
+        pop = pool<list_root>::create(path, "pmse_identlist", 4 * PMEMOBJ_MIN_POOL,
+                                      0664);
         log() << "Engine pool created";
     } else {
-        pop = pool<PmseList>::open(path, "pmse_identlist");
+        pop = pool<list_root>::open(path, "pmse_identlist");
         log() << "Engine pool opened";
     }
 
     try {
-        _identList = pop.get_root();
+        auto root = pop.get_root();
+        if (!root->list_root_ptr) {
+            transaction::exec_tx(pop, [this, &root] {
+                root->list_root_ptr = make_persistent<PmseList>(pop);
+            });
+        }
+        _identList = root->list_root_ptr;
     } catch (std::exception& e) {
         log() << "Error while creating PMSE engine:" << e.what() << std::endl;
     }
     _identList->setPool(pop);
+    if(!_identList->isAfterSafeShutdown()) {
+        _needCheck = true;
+    } else {
+        _needCheck = false;
+    }
+    _identList->resetState();
 }
 
 PmseEngine::~PmseEngine() {
@@ -94,7 +106,8 @@ std::unique_ptr<RecordStore> PmseEngine::getRecordStore(OperationContext* opCtx,
                                                         StringData ident,
                                                         const CollectionOptions& options) {
     _identList->update(ident.toString().c_str(), ns.toString().c_str());
-    return stdx::make_unique<PmseRecordStore>(ns, ident, options, _dbPath, &_poolHandler);
+    return stdx::make_unique<PmseRecordStore>(ns, ident, options, _dbPath,
+                                              &_poolHandler, (_needCheck ? true : false));
 }
 
 Status PmseEngine::createSortedDataInterface(OperationContext* opCtx,

--- a/src/pmse_engine.h
+++ b/src/pmse_engine.h
@@ -137,18 +137,22 @@ class PmseEngine : public KVEngine {
         return _identList->getKeys();
     }
 
-    virtual void cleanShutdown() {}
+    virtual void cleanShutdown() {
+        // If not clean shutdown start scanning all collections
+        _identList->safeShutdown();
+    }
 
     void setJournalListener(JournalListener* jl) final {}
 
  private:
     stdx::mutex _pmutex;
+    bool _needCheck;
     std::map<std::string, pool_base> _poolHandler;
     std::shared_ptr<void> _catalogInfo;
     const std::string _dbPath;
     PMEMobjpool *pm_pool = NULL;
     const StringData _kIdentFilename = "pmkv.pm";
-    pool<PmseList> pop;
+    pool<list_root> pop;
     persistent_ptr<PmseList> _identList;
 };
 }  // namespace mongo

--- a/src/pmse_list.cpp
+++ b/src/pmse_list.cpp
@@ -158,8 +158,24 @@ void PmseList::clear() {
     });
 }
 
-void PmseList::setPool(pool<PmseList> pool_obj) {
+void PmseList::setPool(pool<list_root> pool_obj) {
     this->pool_obj = pool_obj;
+}
+
+bool PmseList::isAfterSafeShutdown() {
+    return _afterSafeShutdown;
+}
+
+void PmseList::resetState() {
+    transaction::exec_tx(pool_obj, [this] {
+        _afterSafeShutdown = false;
+    });
+}
+
+void PmseList::safeShutdown() {
+    transaction::exec_tx(pool_obj, [this] {
+        _afterSafeShutdown = true;
+    });
 }
 
 }  // namespace mongo

--- a/src/pmse_list.h
+++ b/src/pmse_list.h
@@ -60,6 +60,7 @@ struct _values {
     char id[256];
     char value[256];
 };
+struct list_root;
 
 class PmseList {
  public:
@@ -68,7 +69,7 @@ class PmseList {
         persistent_ptr<_pair> next;
     };
     typedef struct _pair KVPair;
-    explicit PmseList(pool<PmseList> obj) : pool_obj(obj) {}
+    explicit PmseList(pool<list_root> obj) : _afterSafeShutdown(true), pool_obj(obj) {}
     PmseList() = delete;
     ~PmseList() = default;
     void insertKV(const char key[], const  char value[]);
@@ -78,13 +79,21 @@ class PmseList {
     std::vector<std::string> getKeys();
     const char* find(const char key[], bool &status);
     void clear();
-    void setPool(pool<PmseList> pool_obj);
+    void setPool(pool<list_root> pool_obj);
+    bool isAfterSafeShutdown();
+    void safeShutdown();
+    void resetState();
  private:
+    p<bool> _afterSafeShutdown = true;
+    p<uint64_t> counter;
     persistent_ptr<KVPair> head;
     persistent_ptr<KVPair> tail;
-    p<uint64_t> counter;
-    pool<PmseList> pool_obj;
+    pool<list_root> pool_obj;
     nvml::obj::mutex _pmutex;
+};
+
+struct list_root {
+    persistent_ptr<PmseList> list_root_ptr;
 };
 
 }  // namespace mongo

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -51,6 +51,7 @@
 #include <libpmemobj++/mutex.hpp>
 #include <libpmemobj++/detail/pexceptions.hpp>
 
+#include <atomic>
 #include <limits>
 
 namespace mongo {
@@ -89,7 +90,7 @@ class PmseMap {
         if (!insertKV(id, value)) {
             return 0;
         }
-        ++_hashmapSize;
+        _hashmapSize.fetch_add(1);
         return id->idValue;
     }
 
@@ -153,7 +154,7 @@ class PmseMap {
     }
 
     bool remove(uint64_t id, OperationContext* txn = nullptr) {
-        _hashmapSize--;
+        _hashmapSize.fetch_sub(1);
         persistent_ptr<KVPair> toDeleted;
         _list[id % _size]->deleteKV(id, toDeleted, txn);
         moveToDeleted(toDeleted, _deleted);
@@ -202,7 +203,7 @@ class PmseMap {
                 initialize(true);
             });
             _counter = 0;
-            _hashmapSize = 0;
+            _hashmapSize = {0};
             _dataSize = 0;
         } catch (nvml::transaction_alloc_error &e) {
             std::cout << e.what() << std::endl;
@@ -251,6 +252,22 @@ class PmseMap {
         return _size;
     }
 
+    void recover() {
+        uint64_t countedSize = 0;
+        uint64_t deletedSize = 0;
+        for(int i = 0; i < _size; i++) {
+            countedSize += _list[i]->size();
+        }
+        _hashmapSize = countedSize;
+        auto cur = _deleted;
+        while(cur) {
+            deletedSize++;
+            cur = cur->next;
+        }
+        // TODO(kfilipek): consider deep recovery (count all physical elements on lists and find max id)
+        _counter = _hashmapSize + deletedSize;
+    }
+
     nvml::obj::mutex _listMutex[HASHMAP_SIZE];
 
  private:
@@ -258,8 +275,8 @@ class PmseMap {
     const bool _isCapped;
     pool_base pop;
     p<uint64_t> _dataSize = 0;
-    p<uint64_t> _counter = 0;
-    p<uint64_t> _hashmapSize = 0;
+    std::atomic<uint64_t> _counter = {1};
+    std::atomic<uint64_t> _hashmapSize = {0};
     p<uint64_t> _maxDocuments;
     p<uint64_t> _sizeOfCollection;
     persistent_ptr<persistent_ptr<PmseListIntPtr>[]> _list;
@@ -274,29 +291,25 @@ class PmseMap {
     }
 
     persistent_ptr<KVPair> getNextId() {
-            persistent_ptr<KVPair> temp = nullptr;
-            if (_deleted == nullptr) {
-                if (_counter != std::numeric_limits<uint64_t>::max()-1) {
-                    this->_counter++;
-                    try {
-                            temp = make_persistent<KVPair>();
-                        temp->idValue = _counter;
-                    } catch (std::exception &e) {
-                        std::cout << "Next id generation: " << e.what() << std::endl;
-                        return nullptr;
-                    }
-                } else {
-                    return nullptr;
-                }
-            } else {
-                stdx::lock_guard<nvml::obj::mutex> guard(_pmutex);
-                temp = _deleted;
-                _deleted = _deleted->next;
-                temp->isDeleted = false;
-                return temp;
+        persistent_ptr<KVPair> temp = nullptr;
+        if (_deleted == nullptr && _counter < std::numeric_limits<uint64_t>::max()) {
+            auto newId = _counter.fetch_add(1);
+            try {
+                temp = make_persistent<KVPair>();
+                temp->idValue = newId;
+            } catch (std::exception &e) {
+                std::cout << "Next id generation: " << e.what() << std::endl;
+                return nullptr;
             }
+        } else {
+            stdx::lock_guard<nvml::obj::mutex> guard(_pmutex);
+            temp = _deleted;
+            _deleted = _deleted->next;
+            temp->isDeleted = false;
             return temp;
         }
+        return temp;
+    }
 };
 
 struct root {

--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -268,6 +268,16 @@ class PmseMap {
         _counter = _hashmapSize + deletedSize;
     }
 
+    void restoreCounters() {
+        _hashmapSize = _pmHashmapSize;
+        _counter = _pmCounter;
+    }
+
+    void storeCounters() {
+        _pmHashmapSize = _hashmapSize.load();
+        _pmCounter = _counter.load();
+    }
+
     nvml::obj::mutex _listMutex[HASHMAP_SIZE];
 
  private:
@@ -277,6 +287,8 @@ class PmseMap {
     p<uint64_t> _dataSize = 0;
     std::atomic<uint64_t> _counter = {1};
     std::atomic<uint64_t> _hashmapSize = {0};
+    p<uint64_t> _pmCounter;
+    p<uint64_t> _pmHashmapSize;
     p<uint64_t> _maxDocuments;
     p<uint64_t> _sizeOfCollection;
     persistent_ptr<persistent_ptr<PmseListIntPtr>[]> _list;

--- a/src/pmse_record_store.cpp
+++ b/src/pmse_record_store.cpp
@@ -112,6 +112,8 @@ PmseRecordStore::PmseRecordStore(StringData ns,
             mapper_root->kvmap_root_ptr->initialize(false);
             if (recoveryNeeded) {
                 mapper_root->kvmap_root_ptr->recover();
+            } else {
+                mapper_root->kvmap_root_ptr->restoreCounters();
             }
         });
     }

--- a/src/pmse_record_store.cpp
+++ b/src/pmse_record_store.cpp
@@ -59,7 +59,8 @@ PmseRecordStore::PmseRecordStore(StringData ns,
                                  StringData ident,
                                  const CollectionOptions& options,
                                  StringData dbpath,
-                                 std::map<std::string, pool_base> *pool_handler)
+                                 std::map<std::string, pool_base> *pool_handler,
+                                 bool recoveryNeeded)
     : RecordStore(ns), _cappedCallback(nullptr),
       _options(options), _dbPath(dbpath) {
     log() << "ns: " << ns;
@@ -107,8 +108,11 @@ PmseRecordStore::PmseRecordStore(StringData ns,
         });
         mapper_root->kvmap_root_ptr->initialize(true);
     } else {
-        transaction::exec_tx(_mapPool, [mapper_root] {
+        transaction::exec_tx(_mapPool, [mapper_root, recoveryNeeded] {
             mapper_root->kvmap_root_ptr->initialize(false);
+            if (recoveryNeeded) {
+                mapper_root->kvmap_root_ptr->recover();
+            }
         });
     }
     try {

--- a/src/pmse_record_store.h
+++ b/src/pmse_record_store.h
@@ -97,7 +97,8 @@ class PmseRecordStore : public RecordStore {
     PmseRecordStore(StringData ns, StringData ident,
                     const CollectionOptions& options,
                     StringData dbpath,
-                    std::map<std::string, pool_base> *pool_handler);
+                    std::map<std::string, pool_base> *pool_handler,
+                    bool recoveryNeeded = false);
 
     ~PmseRecordStore() = default;
 

--- a/src/pmse_record_store.h
+++ b/src/pmse_record_store.h
@@ -100,7 +100,9 @@ class PmseRecordStore : public RecordStore {
                     std::map<std::string, pool_base> *pool_handler,
                     bool recoveryNeeded = false);
 
-    ~PmseRecordStore() = default;
+    ~PmseRecordStore() {
+        _mapper->storeCounters();
+    }
 
     virtual const char* name() const {
         return storeName.c_str();

--- a/src/pmse_sorted_data_interface.h
+++ b/src/pmse_sorted_data_interface.h
@@ -53,7 +53,10 @@ class PmseSortedDataInterface : public SortedDataInterface {
  public:
     PmseSortedDataInterface(StringData ident, const IndexDescriptor* desc,
                             StringData dbpath, std::map<std::string,
-                            pool_base> *pool_handler);
+                            pool_base> *pool_handler,
+                            bool recoveryNeeded = false);
+
+    ~PmseSortedDataInterface();
 
     virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn,
                                                        bool dupsAllowed);
@@ -69,7 +72,7 @@ class PmseSortedDataInterface : public SortedDataInterface {
 
     virtual void fullValidate(OperationContext* txn, long long* numKeysOut,
                               ValidateResults* fullResults) const {
-        *numKeysOut = _tree->_records;
+        *numKeysOut = _tree->_records.load();
         // TODO(kfilipek): Implement fullValidate
     }
 
@@ -85,7 +88,7 @@ class PmseSortedDataInterface : public SortedDataInterface {
     }
 
     virtual bool isEmpty(OperationContext* txn) {
-        return _tree->_records == 0 ? true : false;
+        return _tree->_records.load() == 0 ? true : false;
     }
 
     virtual Status initAsEmpty(OperationContext* txn) {

--- a/src/pmse_tree.h
+++ b/src/pmse_tree.h
@@ -43,6 +43,8 @@
 #include <libpmemobj++/transaction.hpp>
 #include <libpmemobj++/shared_mutex.hpp>
 
+#include <atomic>
+
 #include "mongo/db/storage/sorted_data_interface.h"
 #include "mongo/db/index/index_descriptor.h"
 
@@ -105,13 +107,14 @@ class LocksPtr {
 
 class PmseTree {
     friend class PmseCursor;
+    friend class PmseSortedDataInterface;
 
  public:
     Status insert(pool_base pop, IndexKeyEntry& entry,
                   const BSONObj& _ordering, bool dupsAllowed);
     bool remove(pool_base pop, IndexKeyEntry& entry,
                 bool dupsAllowed, const BSONObj& _ordering, OperationContext* txn);
-    p<int64_t> _records = 0;
+    std::atomic<int64_t> _records = {0};
 
  private:
     void unlockTree(std::list<LocksPtr>& locks);
@@ -168,6 +171,7 @@ class PmseTree {
     persistent_ptr<PmseTreeNode> _root;
     persistent_ptr<PmseTreeNode> _first;
     persistent_ptr<PmseTreeNode> _last;
+    p<int64_t> _records_stored;
     BSONObj _ordering;
 };
 


### PR DESCRIPTION
PR depends on #116 .
Closes #110.
Note: mmap_v1 doesn't have any counter for btree size and there is no implementation for counting.
Note 2: Destructors are not invoked on safe shutdown, so we can't save counters without any tricks in Index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/119)
<!-- Reviewable:end -->
