### PR TITLE
Replace unnecessary counter with counting function

### DIFF
--- a/src/pmse_change.cpp
+++ b/src/pmse_change.cpp
@@ -162,7 +162,6 @@ void InsertIndexChange::rollback() {
         transaction::exec_tx(_pop, [this] {
             IndexKeyEntry entry(_key.getOwned(), _loc);
             _tree->remove(_pop, entry, _dupsAllowed, _desc->keyPattern(), nullptr);
-            --_tree->_records;
         });
     } catch (std::exception &e) {
         log() << e.what();
@@ -178,9 +177,6 @@ void RemoveIndexChange::rollback() {
     Status status = Status::OK();
     IndexKeyEntry entry(_key.getOwned(), _loc);
     status = _tree->insert(_pop, entry, _ordering, _dupsAllowed);
-    if (status == Status::OK()) {
-        ++_tree->_records;
-    }
 }
 
 }  // namespace mongo

--- a/src/pmse_sorted_data_interface.cpp
+++ b/src/pmse_sorted_data_interface.cpp
@@ -98,7 +98,6 @@ Status PmseSortedDataInterface::insert(OperationContext* txn,
         IndexKeyEntry entry(key.getOwned(), loc);
         status = _tree->insert(_pm_pool, entry, _desc->keyPattern(), dupsAllowed);
         if (status == Status::OK()) {
-            ++_tree->_records;
             txn->recoveryUnit()->registerChange(new InsertIndexChange(_tree, _pm_pool, key, loc, dupsAllowed, _desc));
         }
     } catch (std::exception &e) {
@@ -115,9 +114,7 @@ void PmseSortedDataInterface::unindex(OperationContext* txn, const BSONObj& key,
     IndexKeyEntry entry(key.getOwned(), loc);
     try {
         transaction::exec_tx(_pm_pool, [this, &entry, dupsAllowed, txn] {
-            if (_tree->remove(_pm_pool, entry, dupsAllowed,
-                             _desc->keyPattern(), txn))
-                --_tree->_records;
+            _tree->remove(_pm_pool, entry, dupsAllowed, _desc->keyPattern(), txn);
         });
     } catch (std::exception &e) {
         log() << e.what();

--- a/src/pmse_sorted_data_interface.h
+++ b/src/pmse_sorted_data_interface.h
@@ -69,7 +69,7 @@ class PmseSortedDataInterface : public SortedDataInterface {
 
     virtual void fullValidate(OperationContext* txn, long long* numKeysOut,
                               ValidateResults* fullResults) const {
-        *numKeysOut = _tree->_records;
+        *numKeysOut = _tree->countElements();
         // TODO(kfilipek): Implement fullValidate
     }
 
@@ -85,7 +85,7 @@ class PmseSortedDataInterface : public SortedDataInterface {
     }
 
     virtual bool isEmpty(OperationContext* txn) {
-        return _tree->_records == 0 ? true : false;
+        return _tree->isEmpty();
     }
 
     virtual Status initAsEmpty(OperationContext* txn) {
@@ -96,7 +96,6 @@ class PmseSortedDataInterface : public SortedDataInterface {
                     OperationContext* txn, bool isForward) const;
 
  private:
-    void moveToNext();
     StringData _dbpath;
     pool<PmseTree> _pm_pool;
     persistent_ptr<PmseTree> _tree;

--- a/src/pmse_tree.cpp
+++ b/src/pmse_tree.cpp
@@ -37,6 +37,7 @@
 #include "pmse_change.h"
 
 #include <list>
+#include <utility>
 
 #include "mongo/platform/basic.h"
 #include "mongo/db/storage/sorted_data_interface.h"
@@ -298,9 +299,7 @@ persistent_ptr<PmseTreeNode> PmseTree::coalesceNodes(
     IndexKeyEntry k_prime_temp(k_prime.getBSON(), RecordId((k_prime).loc));
     // Swap neighbor with node if node is on the extreme left and neighbor is to its right.
     if (neighbor_index == -1) {
-        tmp = n;
-        n = neighbor;
-        neighbor = tmp;
+        std::swap(n, neighbor);
     }
 
     /*
@@ -886,6 +885,23 @@ Status PmseTree::insert(pool_base pop, IndexKeyEntry& entry,
     }
     unlockTree(locks);
     return Status::OK();
+}
+
+uint64_t PmseTree::countElements() {
+    if (!isEmpty()) {
+        auto leaf = _first;
+        uint64_t counter = 0;
+        while (leaf) {
+            counter += leaf->num_keys;
+            leaf = leaf->next;
+        }
+        return counter;
+    }
+    return 0;
+}
+
+bool PmseTree::isEmpty() {
+    return _first == nullptr;
 }
 
 }  // namespace mongo

--- a/src/pmse_tree.h
+++ b/src/pmse_tree.h
@@ -111,7 +111,10 @@ class PmseTree {
                   const BSONObj& _ordering, bool dupsAllowed);
     bool remove(pool_base pop, IndexKeyEntry& entry,
                 bool dupsAllowed, const BSONObj& _ordering, OperationContext* txn);
-    p<int64_t> _records = 0;
+
+    uint64_t countElements();
+
+    bool isEmpty();
 
  private:
     void unlockTree(std::list<LocksPtr>& locks);


### PR DESCRIPTION
Commit provide function for counting instead of variable.

Explanation:
Function numEntries in SortedDataInterface is invoked only in C++ unit tests, so we don't have to maintain additional variable and add care about synchronization.

PR replace #119 and closes #110
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/120)
<!-- Reviewable:end -->
