### PR TITLE
Corrects update of _last pointer in index

### DIFF
--- a/src/pmse_tree.cpp
+++ b/src/pmse_tree.cpp
@@ -634,7 +634,7 @@ persistent_ptr<PmseTreeNode> PmseTree::splitFullNodeAndInsert(
     new_entry = new_leaf->keys[0];
     new_root = insertIntoNodeParent(pop, _root, node, new_entry, new_leaf);
     new_leaf->_pmutex.unlock();
-    if(node == _last)
+    if (node == _last)
         _last = new_leaf;
     return new_root;
 }

--- a/src/pmse_tree.cpp
+++ b/src/pmse_tree.cpp
@@ -634,7 +634,8 @@ persistent_ptr<PmseTreeNode> PmseTree::splitFullNodeAndInsert(
     new_entry = new_leaf->keys[0];
     new_root = insertIntoNodeParent(pop, _root, node, new_entry, new_leaf);
     new_leaf->_pmutex.unlock();
-    _last = new_leaf;
+    if(node == _last)
+        _last = new_leaf;
     return new_root;
 }
 


### PR DESCRIPTION
Pointer to _last was not updated correctly during splitting of nodes.
This caused errors in iterating backward.
Closes #59.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/125)
<!-- Reviewable:end -->
