### PR TITLE
Corrects validate() function

### DIFF
--- a/src/pmse_record_store.cpp
+++ b/src/pmse_record_store.cpp
@@ -339,17 +339,15 @@ Status PmseRecordStore::validate(OperationContext* txn,
         auto dataSize = record->data.size();
         totalDataSize += dataSize;
         ++nRecords;
-        if (level == kValidateFull) {
-            size_t validatedSize;
-            status = adaptor->validate(record->id, record->data, &validatedSize);
-            if (!status.isOK() || static_cast<size_t>(dataSize) != validatedSize) {
-                if (results->valid) {
-                    results->errors.push_back("detected one or more invalid documents (see logs)");
-                    results->valid = false;
-                }
-                ++nInvalid;
-                log() << "document: RecordId(" << record->id << ") is corruped";
+        size_t validatedSize;
+        status = adaptor->validate(record->id, record->data, &validatedSize);
+        if (!status.isOK() || static_cast<size_t>(dataSize) != validatedSize) {
+            if (results->valid) {
+                results->errors.push_back("detected one or more invalid documents (see logs)");
+                results->valid = false;
             }
+            ++nInvalid;
+            log() << "document: RecordId(" << record->id << ") is corruped";
         }
     }
 


### PR DESCRIPTION
Corrects implementation of validate which requires comparison between
number of documents and number of index entries.
Corrects 25 tests and resmoke tests with suites=core.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/138)
<!-- Reviewable:end -->
