### PR TITLE
Force storing counters before renaming collection

### DIFF
--- a/src/pmse_engine.cpp
+++ b/src/pmse_engine.cpp
@@ -105,6 +105,11 @@ std::unique_ptr<RecordStore> PmseEngine::getRecordStore(OperationContext* opCtx,
                                                         StringData ns,
                                                         StringData ident,
                                                         const CollectionOptions& options) {
+    persistent_ptr<PmseMap<InitData>> _mapper;
+    pool<root> mapPoolOld = pool<root>((_poolHandler)[ident.toString()]);
+    auto mapper_root = mapPoolOld.get_root();
+    _mapper = mapper_root->kvmap_root_ptr;
+    _mapper->storeCounters();
     _identList->update(ident.toString().c_str(), ns.toString().c_str());
     return stdx::make_unique<PmseRecordStore>(ns, ident, options, _dbPath,
                                               &_poolHandler, (_needCheck ? true : false));


### PR DESCRIPTION
Counters will be stored to PM before renaming collection.
Corrects rename2,3,7,8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/140)
<!-- Reviewable:end -->
