### PR TITLE
Corrects seekEndCursor when reached end of list

### DIFF
--- a/src/pmse_index_cursor.h
+++ b/src/pmse_index_cursor.h
@@ -121,7 +121,6 @@ class PmseCursor final : public SortedDataInterface::Cursor {
     boost::optional<EndState> _endState;
     BSONObj _cursorKey;
     int64_t _cursorId;
-    bool _endPositionIsDataEnd;
     bool _locateFoundDataEnd;
     bool _eofRestore;
 };


### PR DESCRIPTION
Corrects fts_diacritic_and_caseinsensitive.js

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/145)
<!-- Reviewable:end -->
