### PR TITLE
Change NVML to PMDK, licence update

### DIFF
--- a/src/pmse_change.cpp
+++ b/src/pmse_change.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_change.h
+++ b/src/pmse_change.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_engine.cpp
+++ b/src/pmse_engine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 

--- a/src/pmse_engine.h
+++ b/src/pmse_engine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,7 +59,7 @@ namespace mongo {
 
 class JournalListener;
 
-using namespace nvml::obj;
+using namespace pmem::obj;
 
 struct ident_entry {
     persistent_ptr<ident_entry> next;

--- a/src/pmse_index_cursor.cpp
+++ b/src/pmse_index_cursor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,7 +56,7 @@ PmseCursor::PmseCursor(OperationContext* txn, bool isForward,
     // Find entry in tree which is equal or bigger to input entry
     // Locates input cursor on that entry
     // Sets _locateFoundDataEnd when result is after last entry in tree
-bool PmseCursor::lower_bound(IndexKeyEntry entry, CursorObject& cursor, std::list<nvml::obj::shared_mutex*>& locks) {
+bool PmseCursor::lower_bound(IndexKeyEntry entry, CursorObject& cursor, std::list<pmem::obj::shared_mutex*>& locks) {
     uint64_t i = 0;
     int64_t cmp;
     persistent_ptr<PmseTreeNode> current = _tree->_root;
@@ -128,7 +128,7 @@ bool PmseCursor::atOrPastEndPointAfterSeeking() {
     }
 }
 
-void PmseCursor::locate(const BSONObj& key, const RecordId& loc, std::list<nvml::obj::shared_mutex*>& locks) {
+void PmseCursor::locate(const BSONObj& key, const RecordId& loc, std::list<pmem::obj::shared_mutex*>& locks) {
     bool locateFound;
     CursorObject locateCursor;
     _isEOF = false;
@@ -181,7 +181,7 @@ void PmseCursor::seekEndCursor() {
 
     if (!_endState || !_tree->_root)
         return;
-    std::list<nvml::obj::shared_mutex*> locks;
+    std::list<pmem::obj::shared_mutex*> locks;
     found = lower_bound(_endState->query, endCursor, locks);
     if (_locateFoundDataEnd) {
         _locateFoundDataEnd = false;
@@ -251,7 +251,7 @@ bool PmseCursor::atEndPoint() {
 
 boost::optional<IndexKeyEntry> PmseCursor::next(
                 RequestedInfo parts = kKeyAndLoc) {
-    std::list<nvml::obj::shared_mutex *> locks;
+    std::list<pmem::obj::shared_mutex *> locks;
 
     if (_tree->_root == nullptr)
         return {};
@@ -288,7 +288,7 @@ boost::optional<IndexKeyEntry> PmseCursor::next(
     return entry;
 }
 
-void PmseCursor::moveToNext(std::list<nvml::obj::shared_mutex*>& locks) {
+void PmseCursor::moveToNext(std::list<pmem::obj::shared_mutex*>& locks) {
     persistent_ptr<PmseTreeNode> node;
     if (_forward) {
         /*
@@ -333,8 +333,8 @@ void PmseCursor::moveToNext(std::list<nvml::obj::shared_mutex*>& locks) {
     }
 }
 
-void PmseCursor::unlockTree(std::list<nvml::obj::shared_mutex*>& locks) {
-    std::list<nvml::obj::shared_mutex*>::const_iterator iterator;
+void PmseCursor::unlockTree(std::list<pmem::obj::shared_mutex*>& locks) {
+    std::list<pmem::obj::shared_mutex*>::const_iterator iterator;
     try {
         for (iterator = locks.begin(); iterator != locks.end(); ++iterator) {
             (*iterator)->unlock_shared();
@@ -348,7 +348,7 @@ boost::optional<IndexKeyEntry> PmseCursor::seek(const BSONObj& key,
                                                 RequestedInfo parts = kKeyAndLoc) {
     if (!_tree->_root)
         return {};
-    std::list<nvml::obj::shared_mutex*> locks;
+    std::list<pmem::obj::shared_mutex*> locks;
 
     if (key.isEmpty()) {
         if (inclusive) {
@@ -389,7 +389,7 @@ boost::optional<IndexKeyEntry> PmseCursor::seek(const IndexSeekPoint& seekPoint,
 
     const BSONObj query = IndexEntryComparison::makeQueryObject(seekPoint, _forward);
     auto discriminator = RecordId::min();
-    std::list<nvml::obj::shared_mutex*> locks;
+    std::list<pmem::obj::shared_mutex*> locks;
     locate(query, _forward ? RecordId::min() : RecordId::max(), locks);
 
     if (_isEOF) {

--- a/src/pmse_index_cursor.h
+++ b/src/pmse_index_cursor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,7 +40,7 @@
 
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 
-using namespace nvml::obj;
+using namespace pmem::obj;
 
 namespace mongo {
 
@@ -95,11 +95,11 @@ class PmseCursor final : public SortedDataInterface::Cursor {
         }
         return bb.obj();
     }
-    void locate(const BSONObj& key, const RecordId& loc, std::list<nvml::obj::shared_mutex*>& locks);
-    void unlockTree(std::list<nvml::obj::shared_mutex*>& locks);
+    void locate(const BSONObj& key, const RecordId& loc, std::list<pmem::obj::shared_mutex*>& locks);
+    void unlockTree(std::list<pmem::obj::shared_mutex*>& locks);
     void seekEndCursor();
-    bool lower_bound(IndexKeyEntry entry, CursorObject& cursor, std::list<nvml::obj::shared_mutex*>& locks);
-    void moveToNext(std::list<nvml::obj::shared_mutex*>& locks);
+    bool lower_bound(IndexKeyEntry entry, CursorObject& cursor, std::list<pmem::obj::shared_mutex*>& locks);
+    void moveToNext(std::list<pmem::obj::shared_mutex*>& locks);
     bool atOrPastEndPointAfterSeeking();
     bool atEndPoint();
     const bool _forward;

--- a/src/pmse_init.cpp
+++ b/src/pmse_init.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_list.cpp
+++ b/src/pmse_list.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,12 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * pmstorekvmapper.cpp
- *
- *  Created on: Mar 24, 2016
- *      Author: kfilipek
- */
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 
 #include "pmse_list.h"
@@ -49,7 +43,7 @@
 namespace mongo {
 
 void PmseList::insertKV(const char key[], const  char value[]) {
-    stdx::lock_guard<nvml::obj::mutex> lock(_pmutex);
+    stdx::lock_guard<pmem::obj::mutex> lock(_pmutex);
     transaction::exec_tx(pool_obj, [this, key, value] {
         persistent_ptr<KVPair> pair;
         try {
@@ -73,7 +67,7 @@ void PmseList::insertKV(const char key[], const  char value[]) {
 }
 
 void PmseList::deleteKV(const char key[]) {
-    stdx::lock_guard<nvml::obj::mutex> lock(_pmutex);
+    stdx::lock_guard<pmem::obj::mutex> lock(_pmutex);
     auto before = head;
     for (auto rec = head; rec != nullptr; rec = rec->next) {
         if (strcmp(rec->kv.get_ro().id, key) == 0) {
@@ -111,7 +105,7 @@ bool PmseList::hasKey(const char key[]) {
 }
 
 std::vector<std::string> PmseList::getKeys() {
-    stdx::lock_guard<nvml::obj::mutex> lock(_pmutex);
+    stdx::lock_guard<pmem::obj::mutex> lock(_pmutex);
     std::vector<std::string> names;
     for (auto rec = head; rec != nullptr; rec = rec->next) {
         names.push_back(rec->kv.get_ro().id);
@@ -120,7 +114,7 @@ std::vector<std::string> PmseList::getKeys() {
 }
 
 const char* PmseList::find(const char key[], bool &status) {
-    stdx::lock_guard<nvml::obj::mutex> lock(_pmutex);
+    stdx::lock_guard<pmem::obj::mutex> lock(_pmutex);
     for (auto rec = head; rec != nullptr; rec = rec->next) {
         if (strcmp(rec->kv.get_ro().id, key) == 0) {
             status = true;
@@ -132,7 +126,7 @@ const char* PmseList::find(const char key[], bool &status) {
 }
 
 void PmseList::update(const char key[], const char value[]) {
-    stdx::lock_guard<nvml::obj::mutex> lock(_pmutex);
+    stdx::lock_guard<pmem::obj::mutex> lock(_pmutex);
     for (auto rec = head; rec != nullptr; rec = rec->next) {
         if (strcmp(rec->kv.get_ro().id, key) == 0) {
             struct _values temp;
@@ -145,7 +139,7 @@ void PmseList::update(const char key[], const char value[]) {
 }
 
 void PmseList::clear() {
-    stdx::lock_guard<nvml::obj::mutex> lock(_pmutex);
+    stdx::lock_guard<pmem::obj::mutex> lock(_pmutex);
     if (!head)
         return;
     transaction::exec_tx(pool_obj, [this] {

--- a/src/pmse_list.h
+++ b/src/pmse_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,14 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * pmstorekvmapper.h
- *
- *  Created on: Mar 24, 2016
- *      Author: kfilipek
- */
-
-
 #ifndef SRC_PMSE_LIST_H_
 #define SRC_PMSE_LIST_H_
 
@@ -52,7 +44,7 @@
 #include <string>
 #include <vector>
 
-using namespace nvml::obj;
+using namespace pmem::obj;
 
 namespace mongo {
 
@@ -89,7 +81,7 @@ class PmseList {
     persistent_ptr<KVPair> head;
     persistent_ptr<KVPair> tail;
     pool<ListRoot> pool_obj;
-    nvml::obj::mutex _pmutex;
+    pmem::obj::mutex _pmutex;
 };
 
 struct ListRoot {

--- a/src/pmse_list_int_ptr.cpp
+++ b/src/pmse_list_int_ptr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,12 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * pmstore_list_int_ptr.cpp
- *
- *  Created on: Sep 22, 2016
- *      Author: kfilipek
- */
 #define MONGO_LOG_DEFAULT_COMPONENT ::mongo::logger::LogComponent::kStorage
 
 #include "pmse_change.h"

--- a/src/pmse_list_int_ptr.h
+++ b/src/pmse_list_int_ptr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,13 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * pmse_list_int_ptr.h
- *
- *  Created on: Sep 22, 2016
- *      Author: kfilipek
- */
-
 #ifndef SRC_PMSE_LIST_INT_PTR_H_
 #define SRC_PMSE_LIST_INT_PTR_H_
 
@@ -52,7 +45,7 @@
 
 #include "mongo/db/operation_context.h"
 
-using namespace nvml::obj;
+using namespace pmem::obj;
 
 namespace mongo {
 struct InitData {

--- a/src/pmse_record_store.cpp
+++ b/src/pmse_record_store.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@
 #include "mongo/db/storage/recovery_unit.h"
 #include "mongo/db/operation_context.h"
 
-using nvml::obj::transaction;
+using pmem::obj::transaction;
 
 namespace mongo {
 
@@ -165,7 +165,7 @@ Status PmseRecordStore::updateRecord(OperationContext* txn, const RecordId& oldL
                                      const char* data, int len, bool enforceQuota,
                                      UpdateNotifier* notifier) {
     persistent_ptr<InitData> obj;
-    stdx::lock_guard<nvml::obj::mutex> lock(_mapper->_listMutex[oldLocation.repr() % _mapper->getHashmapSize()]);
+    stdx::lock_guard<pmem::obj::mutex> lock(_mapper->_listMutex[oldLocation.repr() % _mapper->getHashmapSize()]);
     try {
         transaction::exec_tx(_mapPool, [&obj, len, data, txn, oldLocation, this] {
             obj = pmemobj_tx_alloc(sizeof(InitData::size) + len, 1);
@@ -187,7 +187,7 @@ Status PmseRecordStore::updateRecord(OperationContext* txn, const RecordId& oldL
 
 void PmseRecordStore::deleteRecord(OperationContext* txn,
                                    const RecordId& dl) {
-    stdx::lock_guard<nvml::obj::mutex> lock(_mapper->_listMutex[dl.repr() % _mapper->getHashmapSize()]);
+    stdx::lock_guard<pmem::obj::mutex> lock(_mapper->_listMutex[dl.repr() % _mapper->getHashmapSize()]);
     persistent_ptr<KVPair> p;
     if (_mapper->getPair(dl.repr(), &p)) {
         _mapper->remove((uint64_t) dl.repr(), txn);

--- a/src/pmse_record_store.h
+++ b/src/pmse_record_store.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_recovery_unit.cpp
+++ b/src/pmse_recovery_unit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_recovery_unit.h
+++ b/src/pmse_recovery_unit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_sorted_data_interface.cpp
+++ b/src/pmse_sorted_data_interface.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_sorted_data_interface.h
+++ b/src/pmse_sorted_data_interface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/pmse_tree.cpp
+++ b/src/pmse_tree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +77,7 @@ bool PmseTree::remove(pool_base pop, IndexKeyEntry& entry,
     persistent_ptr<PmseTreeNode> node;
     uint64_t i;
     int64_t cmp;
-    std::list<nvml::obj::shared_mutex*> locks;
+    std::list<pmem::obj::shared_mutex*> locks;
     persistent_ptr<PmseTreeNode> lockNode;
     _ordering = ordering;
     // find node with key
@@ -486,7 +486,7 @@ bool PmseTree::nodeIsSafeForOperation(persistent_ptr<PmseTreeNode> node, bool in
 
 persistent_ptr<PmseTreeNode> PmseTree::locateLeafWithKeyPM(
                 persistent_ptr<PmseTreeNode> node, IndexKeyEntry& entry,
-                const BSONObj& ordering, std::list<nvml::obj::shared_mutex*>& locks,
+                const BSONObj& ordering, std::list<pmem::obj::shared_mutex*>& locks,
                 persistent_ptr<PmseTreeNode>& lockNode, bool insert) {
     uint64_t i = 0;
     int64_t cmp;
@@ -614,7 +614,7 @@ uint64_t PmseTree::cut(uint64_t length) {
 persistent_ptr<PmseTreeNode> PmseTree::splitFullNodeAndInsert(
                 pool_base pop, persistent_ptr<PmseTreeNode> node,
                 IndexKeyEntry& entry, const BSONObj& _ordering,
-                std::list<nvml::obj::shared_mutex*>& locks) {
+                std::list<pmem::obj::shared_mutex*>& locks) {
     persistent_ptr<PmseTreeNode> new_leaf;
     IndexKeyEntry_PM new_entry;
     uint64_t insertion_index = 0;
@@ -836,8 +836,8 @@ persistent_ptr<PmseTreeNode> PmseTree::allocateNewRoot(
     return new_root;
 }
 
-void PmseTree::unlockTree(std::list<nvml::obj::shared_mutex*>& locks) {
-    std::list<nvml::obj::shared_mutex*>::const_iterator iterator;
+void PmseTree::unlockTree(std::list<pmem::obj::shared_mutex*>& locks) {
+    std::list<pmem::obj::shared_mutex*>::const_iterator iterator;
     try {
         for (iterator = locks.begin(); iterator != locks.end(); ++iterator) {
             (*iterator)->unlock();
@@ -852,10 +852,10 @@ Status PmseTree::insert(pool_base pop, IndexKeyEntry& entry,
     Status status = Status::OK();
     uint64_t i;
     int64_t cmp;
-    std::list<nvml::obj::shared_mutex*> locks;
+    std::list<pmem::obj::shared_mutex*> locks;
     persistent_ptr<PmseTreeNode> lockNode;
     if (!_root) {
-        stdx::lock_guard<nvml::obj::mutex> guard(globalMutex);
+        stdx::lock_guard<pmem::obj::mutex> guard(globalMutex);
         if(!_root){
             // root not allocated yet
             try {

--- a/src/pmse_tree.h
+++ b/src/pmse_tree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017, Intel Corporation
+ * Copyright 2014-2018, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@
 #include "mongo/db/storage/sorted_data_interface.h"
 #include "mongo/db/index/index_descriptor.h"
 
-using namespace nvml::obj;
+using namespace pmem::obj;
 
 namespace mongo {
 
@@ -90,7 +90,7 @@ struct PmseTreeNode {
     persistent_ptr<PmseTreeNode> previous = nullptr;
     persistent_ptr<PmseTreeNode> parent = nullptr;
     p<bool> is_leaf = false;
-    nvml::obj::shared_mutex _pmutex;
+    pmem::obj::shared_mutex _pmutex;
 };
 
 struct CursorObject {
@@ -112,8 +112,8 @@ class PmseTree {
     bool isEmpty();
 
  private:
-    nvml::obj::mutex globalMutex;
-    void unlockTree(std::list<nvml::obj::shared_mutex*>& locks);
+    pmem::obj::mutex globalMutex;
+    void unlockTree(std::list<pmem::obj::shared_mutex*>& locks);
     bool nodeIsSafeForOperation(persistent_ptr<PmseTreeNode> node, bool insert);
     uint64_t cut(uint64_t length);
     int64_t getNeighborIndex(persistent_ptr<PmseTreeNode> node);
@@ -133,12 +133,12 @@ class PmseTree {
                              const BSONObj& _ordering);
     persistent_ptr<PmseTreeNode> locateLeafWithKeyPM(
                     persistent_ptr<PmseTreeNode> node, IndexKeyEntry& entry,
-                    const BSONObj& _ordering, std::list<nvml::obj::shared_mutex*>& locks,
+                    const BSONObj& _ordering, std::list<pmem::obj::shared_mutex*>& locks,
                     persistent_ptr<PmseTreeNode>& lockNode, bool insert);
     persistent_ptr<PmseTreeNode> splitFullNodeAndInsert(
                     pool_base pop, persistent_ptr<PmseTreeNode> node,
                     IndexKeyEntry& entry, const BSONObj& _ordering,
-                    std::list<nvml::obj::shared_mutex*>& locks);
+                    std::list<pmem::obj::shared_mutex*>& locks);
     persistent_ptr<PmseTreeNode> insertIntoNodeParent(
                     pool_base pop, persistent_ptr<PmseTreeNode> root,
                     persistent_ptr<PmseTreeNode> node, IndexKeyEntry_PM& new_key,


### PR DESCRIPTION
This PR is required to build PMSE with new version of NVML -> PMDK. They changed namespace from nvml to pmem. I also update year in licence to 2018.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/155)
<!-- Reviewable:end -->
