### PR TITLE
Remove internal PMDK headers from code

### DIFF
--- a/src/pmse_map.h
+++ b/src/pmse_map.h
@@ -41,7 +41,6 @@
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
 #include <libpmemobj++/mutex.hpp>
-#include <libpmemobj++/detail/pexceptions.hpp>
 #include <libpmemobj++/make_persistent_array_atomic.hpp>
 
 #include <atomic>


### PR DESCRIPTION
Linking to internals causes compilation problems (previously defined in ...).
Now can be compiled with the newest PMDK sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmse/176)
<!-- Reviewable:end -->
